### PR TITLE
IIIF adapter modification

### DIFF
--- a/rosa-core/pom.xml
+++ b/rosa-core/pom.xml
@@ -23,4 +23,5 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
 </project>

--- a/rosa-iiif-endpoint/src/main/java/iiif/FSIServer.java
+++ b/rosa-iiif-endpoint/src/main/java/iiif/FSIServer.java
@@ -103,6 +103,8 @@ public class FSIServer implements ImageServer {
             width = scale.getWidth();
             height = -1;
         } else if (scale.getType() == Size.Type.FULL) {
+            width = (int) ((right - left) * info.getWidth());
+            height = (int) ((bottom - top) * info.getHeight());
         } else if (scale.getType() == Size.Type.PERCENTAGE) {
             width = (int) ((right - left) * info.getWidth() * (scale
                     .getPercentage() / 100));

--- a/rosa-iiif-endpoint/src/main/java/iiif/IIIFSerializer.java
+++ b/rosa-iiif-endpoint/src/main/java/iiif/IIIFSerializer.java
@@ -37,14 +37,14 @@ public class IIIFSerializer {
         Element id = doc.createElementNS(ns, "identifier");
         id.setTextContent(info.getId());
         root.appendChild(id);
+	// As it turns out, "@" is an invalid starting character for an xml tag.
+	// Element atId = doc.createElementNS(ns, "@id");
+	// atId.setTextContent(baseUri + "/" + URLEncoder.encode(info.getId()));
+	// root.appendChild(atId);
 
-	Element atId = doc.createElementNS(ns, "@id");
-	atId.setTextContent(baseUri + URLEncoder.encode(info.getId()));
-	root.appendChild(atId);
-
-	Element atContext = doc.createElementNS(ns, "@context");
-        atId.setTextContent("http://library.stanford.edu/iiif/image-api/1.1/context.json");
-        root.appendChild(atContext);
+	// Element atContext = doc.createElementNS(ns, "@context");
+        // atContext.setTextContent("http://library.stanford.edu/iiif/image-api/1.1/context.json");
+        // root.appendChild(atContext);
 
         Element width = doc.createElementNS(ns, "width");
         width.setTextContent(info.getWidth() + "");
@@ -118,9 +118,11 @@ public class IIIFSerializer {
         JSONObject root = new JSONObject();
         
 	root.put("@context", "http://library.stanford.edu/iiif/image-api/1.1/context.json");
-        root.put("@id", baseUri + URLEncoder.encode(info.getId()));
+        root.put("@id", baseUri + "/" + URLEncoder.encode(info.getId()));
+	root.put("identifier", URLEncoder.encode(info.getId()));
         root.put("width", info.getWidth());
         root.put("height", info.getHeight());
+	root.put("profile", "http://library.stanford.edu/iiif/image-api/compliance.html#level1");
         
         if (info.getTileWidth() > 0 && info.getTileHeight() > 0) {
             root.put("tile_width", info.getTileWidth());

--- a/rosa-iiif-endpoint/src/main/java/iiif/IIIFSerializer.java
+++ b/rosa-iiif-endpoint/src/main/java/iiif/IIIFSerializer.java
@@ -118,13 +118,13 @@ public class IIIFSerializer {
         JSONObject root = new JSONObject();
         
 	root.put("@context", "http://library.stanford.edu/iiif/image-api/1.1/context.json");
-//        root.put("@id", baseUri + "/" + URLEncoder.encode(info.getId()));
-        root.put("@id", baseUri + "/" + info.getId());
-	root.put("identifier", info.getId());
+        root.put("@id", baseUri + "/" + URLEncoder.encode(info.getId()));
+//        root.put("@id", baseUri + "/" + info.getId());
+//	root.put("identifier", info.getId());
 //	root.put("identifier", URLEncoder.encode(info.getId()));
         root.put("width", info.getWidth());
         root.put("height", info.getHeight());
-	root.put("profile", "http://library.stanford.edu/iiif/image-api/compliance.html#level1");
+	root.put("profile", "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level1");
         
         if (info.getTileWidth() > 0 && info.getTileHeight() > 0) {
             root.put("tile_width", info.getTileWidth());

--- a/rosa-iiif-endpoint/src/main/java/iiif/IIIFSerializer.java
+++ b/rosa-iiif-endpoint/src/main/java/iiif/IIIFSerializer.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 
+import java.net.URLEncoder;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -21,7 +23,7 @@ import org.w3c.dom.Element;
 
 public class IIIFSerializer {
 
-    public void toXML(ImageInfo info, OutputStream os)
+    public void toXML(ImageInfo info, OutputStream os, String baseUri)
             throws ParserConfigurationException, TransformerException {
         DocumentBuilderFactory docFactory = DocumentBuilderFactory
                 .newInstance();
@@ -35,6 +37,14 @@ public class IIIFSerializer {
         Element id = doc.createElementNS(ns, "identifier");
         id.setTextContent(info.getId());
         root.appendChild(id);
+
+	Element atId = doc.createElementNS(ns, "@id");
+	atId.setTextContent(baseUri + URLEncoder.encode(info.getId()));
+	root.appendChild(atId);
+
+	Element atContext = doc.createElementNS(ns, "@context");
+        atId.setTextContent("http://library.stanford.edu/iiif/image-api/1.1/context.json");
+        root.appendChild(atContext);
 
         Element width = doc.createElementNS(ns, "width");
         width.setTextContent(info.getWidth() + "");
@@ -104,10 +114,11 @@ public class IIIFSerializer {
         transformer.transform(source, result);
     }
 
-    public void toJSON(ImageInfo info, OutputStream os) throws JSONException, IOException {
+    public void toJSON(ImageInfo info, OutputStream os, String baseUri) throws JSONException, IOException {
         JSONObject root = new JSONObject();
         
-        root.put("identifier", info.getId());
+	root.put("@context", "http://library.stanford.edu/iiif/image-api/1.1/context.json");
+        root.put("@id", baseUri + URLEncoder.encode(info.getId()));
         root.put("width", info.getWidth());
         root.put("height", info.getHeight());
         

--- a/rosa-iiif-endpoint/src/main/java/iiif/IIIFSerializer.java
+++ b/rosa-iiif-endpoint/src/main/java/iiif/IIIFSerializer.java
@@ -118,8 +118,10 @@ public class IIIFSerializer {
         JSONObject root = new JSONObject();
         
 	root.put("@context", "http://library.stanford.edu/iiif/image-api/1.1/context.json");
-        root.put("@id", baseUri + "/" + URLEncoder.encode(info.getId()));
-	root.put("identifier", URLEncoder.encode(info.getId()));
+//        root.put("@id", baseUri + "/" + URLEncoder.encode(info.getId()));
+        root.put("@id", baseUri + "/" + info.getId());
+	root.put("identifier", info.getId());
+//	root.put("identifier", URLEncoder.encode(info.getId()));
         root.put("width", info.getWidth());
         root.put("height", info.getHeight());
 	root.put("profile", "http://library.stanford.edu/iiif/image-api/compliance.html#level1");

--- a/rosa-iiif-endpoint/src/main/java/iiif/IIIFServlet.java
+++ b/rosa-iiif-endpoint/src/main/java/iiif/IIIFServlet.java
@@ -117,6 +117,7 @@ public class IIIFServlet extends HttpServlet {
 
         String context = req.getContextPath();
         StringBuffer sb = req.getRequestURL();
+        String baseServletUri = req.getScheme() + "://" + req.getServerName() + ":" + req.getServerPort() + req.getServletPath() + req.getContextPath();
         int i = sb.indexOf(context);
 
         if (i == -1) {
@@ -139,7 +140,7 @@ public class IIIFServlet extends HttpServlet {
 
                     try {
                         if (inforeq.getFormat() == InfoFormat.XML) {
-                            serializer.toXML(info, os);
+                            serializer.toXML(info, os, baseServletUri);
                         } else if (inforeq.getFormat() == InfoFormat.JSON) {
                             String callback = req.getParameter("callback");
 
@@ -148,7 +149,7 @@ public class IIIFServlet extends HttpServlet {
                                 os.write('(');
                             }
 
-                            serializer.toJSON(info, os);
+                            serializer.toJSON(info, os, baseServletUri);
                             if (callback != null) {
                                 os.write(')');
                             }

--- a/rosa-iiif-endpoint/src/main/java/iiif/IIIFServlet.java
+++ b/rosa-iiif-endpoint/src/main/java/iiif/IIIFServlet.java
@@ -111,7 +111,7 @@ public class IIIFServlet extends HttpServlet {
 
         resp.addHeader(
                 "Link",
-                "<http://library.stanford.edu/iiif/image-api/compliance.html#level0>;rel=\"profile\"");
+                "<http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level1>;rel=\"profile\"");
 
         // Hack to get undecoded path;
 

--- a/rosa-iiif-endpoint/src/main/webapp/WEB-INF/web.xml
+++ b/rosa-iiif-endpoint/src/main/webapp/WEB-INF/web.xml
@@ -12,7 +12,7 @@
    <init-param>
       <param-name>fsi.url</param-name> 
       <!--param-value>http://fsiserver.library.jhu.edu/server</param-value-->
-      <param-value>http://10.238.232.40:5050/fsi/server</param-value>
+      <param-value>http://localhost:5050/fsi/server</param-value>
     </init-param>
 
    <!-- Stanford IIIF validator requires certain name for test image. -->

--- a/rosa-iiif-endpoint/src/main/webapp/WEB-INF/web.xml
+++ b/rosa-iiif-endpoint/src/main/webapp/WEB-INF/web.xml
@@ -12,7 +12,7 @@
    <init-param>
       <param-name>fsi.url</param-name> 
       <!--param-value>http://fsiserver.library.jhu.edu/server</param-value-->
-      <param-value>http://10.238.232.40:5050/fsi/server</param-value> 
+      <param-value>http://10.238.232.40:5050/fsi/server</param-value>
     </init-param>
 
    <!-- Stanford IIIF validator requires certain name for test image. -->
@@ -21,9 +21,10 @@
       <param-value>test/f23dc590-8736-11e2-a400-0050569b3c3f.png</param-value> 
     </init-param>
    <init-param>
-      <param-name>alias.thingy</param-name> 
+      <param-name>alias.testimage</param-name> 
       <param-value>Stor/2013/11/01/05/4c770cb6-5ddc-4989-a111-b15d781e8d2a.jpg</param-value> 
     </init-param>
+   
   </servlet>
 
   <servlet-mapping>

--- a/rosa-iiif-endpoint/src/main/webapp/WEB-INF/web.xml
+++ b/rosa-iiif-endpoint/src/main/webapp/WEB-INF/web.xml
@@ -11,13 +11,18 @@
 
    <init-param>
       <param-name>fsi.url</param-name> 
-      <param-value>http://fsiserver.library.jhu.edu/server</param-value> 
+      <!--param-value>http://fsiserver.library.jhu.edu/server</param-value-->
+      <param-value>http://10.238.232.40:5050/fsi/server</param-value> 
     </init-param>
 
    <!-- Stanford IIIF validator requires certain name for test image. -->
    <init-param>
       <param-name>alias.f23dc590-8736-11e2-a400-0050569b3c3f</param-name> 
       <param-value>test/f23dc590-8736-11e2-a400-0050569b3c3f.png</param-value> 
+    </init-param>
+   <init-param>
+      <param-name>alias.thingy</param-name> 
+      <param-value>Stor/2013/11/01/05/4c770cb6-5ddc-4989-a111-b15d781e8d2a.jpg</param-value> 
     </init-param>
   </servlet>
 

--- a/rosa-iiif-endpoint/src/test/java/iiif/IIIFSerializerTest.java
+++ b/rosa-iiif-endpoint/src/test/java/iiif/IIIFSerializerTest.java
@@ -16,7 +16,7 @@ public class IIIFSerializerTest extends TestCase {
         info.setTileHeight(100);
         info.setTileWidth(200);
         
-        new IIIFSerializer().toXML(info, System.out);
+        new IIIFSerializer().toXML(info, System.out, "/bleh/");
     }
     
     public void testImageInfoJSON() throws Exception {
@@ -31,6 +31,6 @@ public class IIIFSerializerTest extends TestCase {
         info.setTileHeight(100);
         info.setTileWidth(200);
         
-        new IIIFSerializer().toJSON(info, System.out);
+        new IIIFSerializer().toJSON(info, System.out, "/blah/");
     }
 }


### PR DESCRIPTION
This pull request contains changes so that the IIIF adapter conforms to the IIIF Image API 1.1 spec when serving the "image info" JSON request. Also, the Image API 1.1 does not require an XML info response which is why that one does not contain the same changes.
